### PR TITLE
* fixed multiple calls from same org issue - only 1 ongoing contest f…

### DIFF
--- a/lotto.sol
+++ b/lotto.sol
@@ -4,7 +4,6 @@ import "zeppelin-solidity/contracts/token/StandardToken.sol";
 
 /* A single organizer address cannot have more than 1 contest running simulatenously */
 /* A single winner of each contest */
-/* need to clean up after contest ends */
 /* Need to port to SafeMath */
 
 contract Lotto {
@@ -32,17 +31,28 @@ struct one_lot {
 // time when this Lotto was created
     uint creation_time;
 
+// content running 
+    bool contest_running;
+
 
 }
 
 mapping (address => one_lot) public all_lot;
 
-address public LOTaddress ;
-StandardToken public lottok;
+address LOTaddress ;
+StandardToken lottok;
+address must_be_from;
+bool is_first_time = true;
 
 //sta = set token address
 function set_sta(address tok_addr) public 
 {
+    if( is_first_time == true)
+    {
+	is_first_time = false;
+        must_be_from = msg.sender;
+    }
+    require(must_be_from == msg.sender);
     lottok = StandardToken(tok_addr);
     LOTaddress = tok_addr;
 }
@@ -59,13 +69,21 @@ function get_sta() public constant returns (address)
 
 function Organize(uint lotto_hold_time, uint participant_contribution, address lotto_trigger, uint256 organizer_contrib) public 
 {
+
+
+    require(all_lot[msg.sender].contest_running == false);
     require(lottok.allowance(msg.sender, this) >= organizer_contrib);
+    require(participant_contribution > 0);
+    require(lotto_hold_time > 0);
+    require(organizer_contrib > 0);
+   
     
+    all_lot[msg.sender].contest_running = true;
     all_lot[msg.sender].organizer = msg.sender;
     all_lot[msg.sender].hold_time = lotto_hold_time;
     all_lot[msg.sender].contribution_req = participant_contribution;
     all_lot[msg.sender].trigger = lotto_trigger;
-    all_lot[msg.sender].pool_amount += organizer_contrib;
+    all_lot[msg.sender].pool_amount = organizer_contrib;
     
     // Transfer organizer_contrib from the organizer wallet to the contract
 
@@ -116,18 +134,24 @@ function gettri(address org) public constant returns (address) {
 // Draw the lottery and transfer funds to the winner
 // random_number is between 0 and number of participants 
 function draw(uint random_number, address org) public {
+
+    require(all_lot[org].contest_running ==true);
     require(all_lot[org].pool_amount >0);
     require (msg.sender == all_lot[org].trigger);
+
 //    require ( (random_number >=0) && (random_number < (participants.length -1)));
 
     address winner = all_lot[org].participants[random_number];
 
-    //TBD transfer "pool_amount" funds to winner 
+//transfer "pool_amount" funds to winner 
 
-//lottok.transferFrom(this, winner , pool_amount);
-lottok.transfer(winner , all_lot[org].pool_amount);
+    lottok.transfer(winner , all_lot[org].pool_amount);
 
- //  return winner;
+//clean up
+
+    all_lot[org].contest_running = false;
+    all_lot[org].participants.length = 0;
+
 
 }
 
@@ -146,8 +170,6 @@ function dp(uint random_number, address org) public constant returns (address) {
 
 return winner;
 
-    //TBD transfer "pool_amount" funds to winner 
-//lottok.transferFrom(this, winner , pool_amount);
 
 }
 

--- a/testToken.js
+++ b/testToken.js
@@ -46,11 +46,12 @@ contract('Lotto', (accounts) => {
     //console.log('results', results)
 
 
+
     let totalSuppy = await token.totalSupply()
     assert.equal(new BigNumber(totalSuppy).toString(), new BigNumber(13000).toString(), 'Initial supply should be 13 Thousand')
 
     let symbol = await token.symbol()
-    assert.equal(symbol, 'LOTT')
+    assert.equal(symbol, 'MOTT')
 
     let name = await token.name()
     assert.equal(name, 'TutorialToken')
@@ -98,6 +99,10 @@ contract('Lotto', (accounts) => {
 // organize contest and seed with 7 tokens, but participants must contribute 5 tokens each 
     await token.approve( lto.address , 7 , {from: o})
     await lto.Organize(30,5,t,7, {from: o})
+
+//trying to organize a second time from the same organizer while a contest is running should fail
+//    await token.approve( lto.address , 1 , {from: o})
+//    await lto.Organize(30,1,t,1, {from: o})
 
 
 // lets organize our second contest - p3 is our second organizer
@@ -187,7 +192,6 @@ contract('Lotto', (accounts) => {
     assert.equal(fmt2,26);
 
 // ok draw for 2nd contest now
-// lucky guy - wins both contests !!!!
 
     let win2= await lto.dp(0,p3, {from: t})
 
@@ -200,6 +204,21 @@ contract('Lotto', (accounts) => {
 // wins 4 tokens + 4 leftover = 8
 
     assert.equal(fmt4,8);
+
+
+//make sure only we can call set_sta - commenting out since following test should fail
+//    await lto.set_sta(p2, {from: t})
+    let still_the_same = await lto.get_sta()
+    assert.equal(token.address, still_the_same)
+
+//trying to organize a second time from the same organizer after contest has ended
+    await token.approve( lto.address , 1 , {from: o})
+    await lto.Organize(30,1,t,1, {from: o})
+    await token.approve( lto.address , 1 , {from: p})
+    await lto.Participate ( 1 , o, {from :p})
+    await token.approve( lto.address , 1 , {from: p2})
+    await lto.Participate ( 1 , o, {from :p2})
+    await lto.draw(1, o, {from: t})
 
   })
 })


### PR DESCRIPTION
…rom a single orgainzer at any time. Subsequent calls will be rejected

* fixed - only we can program the token address
* fixed clean up at the end of a draw
* tested - same organizer can have 2nd contest after the draw of the first contest is over